### PR TITLE
Meta Refresh

### DIFF
--- a/lib/extract_url.ex
+++ b/lib/extract_url.ex
@@ -1,6 +1,7 @@
 defmodule ExtractUrl do
   def call(url) do
     url
+    |> URI.encode
     |> URI.parse
     |> prune
   end

--- a/lib/extract_url.ex
+++ b/lib/extract_url.ex
@@ -1,7 +1,6 @@
 defmodule ExtractUrl do
   def call(url) do
     url
-    |> URI.encode
     |> URI.parse
     |> prune
   end

--- a/lib/redir.ex
+++ b/lib/redir.ex
@@ -10,15 +10,18 @@ defmodule Redir do
 
   defp parse_url(url) do
     case get(url) do
-      {:ok, %HTTPoison.Response{status_code: 200}} ->
-        url
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        cond do
+          contains_meta_refresh?(body) -> url_with_meta(body)
+          true -> url
+        end
       {:ok, %HTTPoison.Response{status_code: 500}} ->
         "Server error!"
       {:ok, %HTTPoison.Response{status_code: 302, headers: headers}} ->
         get_url_from_header(headers)
       {:ok, %HTTPoison.Response{status_code: 301, headers: headers}} ->
         get_url_from_header(headers)
-      {:ok, %HTTPoison.Response{status_code: _not_found, headers: headers}} ->
+      {:ok, %HTTPoison.Response{status_code: _not_found}} ->
         "Not found!"
       {:error, %HTTPoison.Error{reason: reason}} ->
         reason
@@ -30,5 +33,23 @@ defmodule Redir do
     |> List.keyfind("Location", 0)
     |> elem(1)
     |> parse_url
+  end
+
+  defp contains_meta_refresh?(body) do
+    body
+    |> String.contains?("meta http-equiv=")
+  end
+
+  defp url_with_meta(body) do
+    body
+    |> Floki.attribute("meta", "content")
+    |> List.last()
+    |> parsed_meta
+  end
+
+  defp parsed_meta(content) do
+    content
+    |> String.split("=")
+    |> List.last
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -27,6 +27,7 @@ defmodule Redir.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:httpoison, "~> 0.8.0"}]
+    [{:httpoison, "~> 0.8.0"},
+     {:floki, "~> 0.8.1"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,9 @@
-%{"certifi": {:hex, :certifi, "0.4.0"},
-  "hackney": {:hex, :hackney, "1.6.0"},
-  "httpoison": {:hex, :httpoison, "0.8.3"},
-  "idna": {:hex, :idna, "1.2.0"},
-  "metrics": {:hex, :metrics, "1.0.1"},
-  "mimerl": {:hex, :mimerl, "1.0.2"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0"}}
+%{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
+  "floki": {:hex, :floki, "0.8.1", "06aa75bf2d1e01cda7d2ad54f68614be653a11e76b474d8fcb1d838f8c1e0ad1", [:mix], [{:mochiweb_html, "~> 2.15", [hex: :mochiweb_html, optional: false]}]},
+  "hackney": {:hex, :hackney, "1.6.0", "8d1e9440c9edf23bf5e5e2fe0c71de03eb265103b72901337394c840eec679ac", [:rebar3], [{:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:certifi, "0.4.0", [hex: :certifi, optional: false]}]},
+  "httpoison": {:hex, :httpoison, "0.8.3", "b675a3fdc839a0b8d7a285c6b3747d6d596ae70b6ccb762233a990d7289ccae4", [:mix], [{:hackney, "~> 1.6.0", [hex: :hackney, optional: false]}]},
+  "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
+  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
+  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
+  "mochiweb_html": {:hex, :mochiweb_html, "2.15.0", "d7402e967d7f9f2912f8befa813c37be62d5eeeddbbcb6fe986c44e01460d497", [:rebar3], []},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []}}

--- a/test/redir_test.exs
+++ b/test/redir_test.exs
@@ -23,6 +23,12 @@ defmodule RedirTest do
     assert Redir.final_url(uri) == "Server error!"
   end
 
+  test "infinite" do
+    Redir.start
+    uri = "http://httpmock.herokuapp.com/redirect-with-meta?to=http://brewhouse.io"
+    assert Redir.final_url(uri) == "http://brewhouse.io"
+  end
+
 # http => http
 # https => http
 # http => https


### PR DESCRIPTION
Follow a redirect on a site with meta refresh

For sites that has meta tags that redirects, we should follow the link to it.
