### PR TITLE
location without scheme and host

### DIFF
--- a/lib/extract_url.ex
+++ b/lib/extract_url.ex
@@ -6,6 +6,11 @@ defmodule ExtractUrl do
     |> prune
   end
 
+  def add_base_url(base_url, url) do
+    base = URI.parse(base_url)
+    "#{base.scheme}://#{base.host}#{url}"
+  end
+
   defp prune(uri) do
     cond do
       has_invalid_scheme(uri.scheme) -> raise UriError.InvalidSchemeError

--- a/test/redir_test.exs
+++ b/test/redir_test.exs
@@ -29,6 +29,12 @@ defmodule RedirTest do
     assert Redir.final_url(uri) == "http://brewhouse.io"
   end
 
+  test "301 with location without a host or scheme" do
+    Redir.start
+    uri = "https://www.pagerduty.com/lp/saas-on-the-line/"
+    assert Redir.final_url(uri) == "https://www.pagerduty.com/lp/d/saas-on-the-line/"
+  end
+
 # http => http
 # https => http
 # http => https


### PR DESCRIPTION
It seems like some of the url on a `location` header does not have a scheme or host.

If given a url of `http://paulo.com/this-is-a-301` with a header of `/redirect-to-this`, we then should redirect them to `http://paulo.com/redirect-to-this`
