### PR TITLE
rescue against bad request

### DIFF
--- a/lib/redir.ex
+++ b/lib/redir.ex
@@ -9,19 +9,23 @@ defmodule Redir do
   end
 
   defp parse_url(url) do
-    case get(url) do
-      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        cond do
-          contains_meta_refresh?(body) -> url_with_meta(body)
-          true -> url
-        end
-      {:ok, %HTTPoison.Response{status_code: 302, headers: headers}} ->
-        get_url_from_header(url, headers)
-      {:ok, %HTTPoison.Response{status_code: 301, headers: headers}} ->
-        get_url_from_header(url, headers)
-      {:ok, %HTTPoison.Response{status_code: 500}} -> "Server error!"
-      {:ok, %HTTPoison.Response{status_code: _not_found}} -> "Not found!"
-      {:error, %HTTPoison.Error{reason: reason}} -> reason
+    try do
+      case get(url) do
+        {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+          cond do
+            contains_meta_refresh?(body) -> url_with_meta(body)
+            true -> url
+          end
+        {:ok, %HTTPoison.Response{status_code: 302, headers: headers}} ->
+          get_url_from_header(url, headers)
+        {:ok, %HTTPoison.Response{status_code: 301, headers: headers}} ->
+          get_url_from_header(url, headers)
+        {:ok, %HTTPoison.Response{status_code: 500}} -> "Server error!"
+        {:ok, %HTTPoison.Response{status_code: _not_found}} -> "Not found!"
+        {:error, %HTTPoison.Error{reason: reason}} -> reason
+      end
+    rescue
+      e in CaseClauseError -> e
     end
   end
 

--- a/test/redir_test.exs
+++ b/test/redir_test.exs
@@ -35,6 +35,12 @@ defmodule RedirTest do
     assert Redir.final_url(uri) == "https://www.pagerduty.com/lp/d/saas-on-the-line/"
   end
 
+  test "with bad request" do
+    Redir.start
+    uri = "http://talk.buildinbombay.com/t/build-in-bombay-s-aua-with-super"
+    assert Redir.final_url(uri) == %CaseClauseError{term: {:error, :bad_request}}
+  end
+
 # http => http
 # https => http
 # http => https


### PR DESCRIPTION
bad request error on HTTPoison does not have a clause matching `:bad_request`
